### PR TITLE
Implement non-deprecated cli with structopts and adf-state-safer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adf_bdd"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -18,6 +18,7 @@ dependencies = [
  "quickcheck_macros",
  "serde",
  "serde_json",
+ "structopt",
  "test-log",
 ]
 
@@ -230,6 +231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +395,30 @@ checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -561,6 +595,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +686,12 @@ checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 
 [dependencies]
 clap = "2.33.*"
+structopt = "0.3.25"
 log = { version = "0.4", features = [ "max_level_trace", "release_max_level_info" ] }
 env_logger = "0.9"
 nom = "7.1.0"

--- a/src/datatypes/adf.rs
+++ b/src/datatypes/adf.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, collections::HashMap, fmt::Display, rc::Rc};
 
 use super::{Term, Var};
 
-#[derive(Serialize, Deserialize,Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct VarContainer {
     names: Rc<RefCell<Vec<String>>>,
     mapping: Rc<RefCell<HashMap<String, usize>>>,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,6 +52,12 @@ fn runs() -> Result<(), Box<dyn std::error::Error>> {
     ));
 
     cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(file.path()).arg("-q").arg("--grd");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
     cmd.arg(file.path()).arg("--lx").arg("-v").arg("--grd");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(10) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9)",
@@ -59,6 +65,64 @@ fn runs() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd = Command::cargo_bin("adf_bdd")?;
     cmd.arg(file.path()).arg("--an").arg("--grd").arg("--stm");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.env_clear();
+    cmd.arg(file.path()).arg("--an").arg("--grd");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(file.path())
+        .arg("--an")
+        .arg("--grd")
+        .arg("--rust_log")
+        .arg("trace");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(file.path())
+        .arg("--an")
+        .arg("--grd")
+        .arg("--rust_log")
+        .arg("warn");
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    let tempdir = assert_fs::TempDir::new()?;
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(file.path())
+        .arg("--an")
+        .arg("--grd")
+        .arg("--export")
+        .arg(tempdir.path().with_file_name("test.json"));
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(file.path())
+        .arg("--an")
+        .arg("--grd")
+        .arg("--export")
+        .arg(tempdir.path().with_file_name("test.json"));
+    cmd.assert().success().stdout(predicate::str::contains(
+        "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
+    ));
+
+    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd.arg(tempdir.path().with_file_name("test.json"))
+        .arg("--an")
+        .arg("--grd")
+        .arg("--import");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n\n",
     ));


### PR DESCRIPTION
Rework of the CLI methods.

Added import/export functionality for ADFs in BDD representation (via JSON serialisation)