### PR TITLE
Update rust-analyzer, Bump flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
@@ -15,11 +16,12 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, gitignoresrc, rust-overlay, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, flake-compat, gitignoresrc, rust-overlay, ... }@inputs:
     {
       #overlay = import ./nix { inherit gitignoresrc; };
     } // (flake-utils.lib.eachDefaultSystem (system:
       let
+        unstable = import nixpkgs-unstable { inherit system; };
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ (import rust-overlay)];
@@ -33,7 +35,7 @@
             buildInputs = [
               pkgs.rust-bin.nightly.latest.rustfmt
               pkgs.rust-bin.stable.latest.default
-              pkgs.rust-analyzer
+              unstable.rust-analyzer
               pkgs.cargo-audit
               pkgs.cargo-license
               pkgs.cargo-tarpaulin


### PR DESCRIPTION
# What does this PR do?

Updates the developer environment to use the newest rust-analyzer version.