### PR TITLE
Update crates.io usage for the binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "adf_bdd"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e781519ea5434514f014476c02ccee777b28e600ad58fadca195715acb194c69"
+dependencies = [
+ "biodivine-lib-bdd",
+ "derivative",
+ "lexical-sort",
+ "log",
+ "nom",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "adf_bdd-solver"
 version = "0.2.4"
 dependencies = [
- "adf_bdd",
+ "adf_bdd 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd",
  "assert_fs",
  "clap",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -10,11 +10,11 @@ description = "Solver for ADFs grounded, complete, and stable semantics by utili
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
-name = "adf_bdd"
+name = "adf-bdd"
 path = "src/main.rs"
 
 [dependencies]
-adf_bdd = { path = "../lib", default-features = false }
+adf_bdd = { version="0.2.4", default-features = false }
 clap = {version = "3.1.8", features = [ "derive", "cargo", "env" ]}
 log = { version = "0.4", features = [ "max_level_trace", "release_max_level_info" ] }
 serde = { version = "1.0", features = ["derive","rc"] }

--- a/bin/tests/cli.rs
+++ b/bin/tests/cli.rs
@@ -5,25 +5,25 @@ use std::process::Command; // Run programs
 
 #[test]
 fn arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let mut cmd = Command::cargo_bin("adf_bdd")?;
+    let mut cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg("-vvv").arg("--lx").arg("file.txt");
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("No such file or directory"));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg("-v").arg("--lx").arg("--an").arg("file.txt");
     cmd.assert().failure().stderr(predicate::str::contains(
         "The argument '--lx' cannot be used with '--an'",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg("-h");
     cmd.assert().success().stdout(predicate::str::contains(
         "stefan.ellmauthaler@tu-dresden.de",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg("--version");
     cmd.assert()
         .success()
@@ -38,14 +38,14 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
     let wrong_file = assert_fs::NamedTempFile::new("wrong_format.adf")?;
     wrong_file.write_str("s(7).s(4).s(8).s(3).s(5).s(9).s(10).s(1).s(6).s(2).ac(7,or(or(and(7,neg(1)),neg(9)),3)).ac(4,5).ac(8,or(or(8,1),neg(7))).ac(3,or(and(or(6,7),neg(and(6,7))),neg(2))).ac(5,c(f)).ac(9,and(neg(7),2)).ac(10,or(neg(2),6)).ac(1,and(or(or(neg(2),neg(1)),8),7)).ac(6,and(and(neg(2),10),and(or(7,4),neg(and(7,4))))).ac(2,and(and(and(neg(10),3),neg(6)),or(9,1)))).")?;
 
-    let mut cmd = Command::cargo_bin("adf_bdd")?;
+    let mut cmd = Command::cargo_bin("adf-bdd")?;
 
     cmd.arg(wrong_file.path());
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("code: Eof"));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("-vv")
         .arg("--grd")
@@ -55,7 +55,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("-q")
         .arg("--grd")
@@ -65,7 +65,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--lx")
         .arg("-v")
@@ -76,7 +76,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(10) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -87,7 +87,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.env_clear();
     cmd.arg(file.path())
         .arg("--an")
@@ -98,7 +98,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -110,7 +110,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -124,7 +124,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
 
     let tempdir = assert_fs::TempDir::new()?;
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -136,7 +136,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -148,7 +148,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(tempdir.path().with_file_name("test.json"))
         .arg("--an")
         .arg("--grd")
@@ -159,7 +159,7 @@ fn runs_naive() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--com")
@@ -180,45 +180,45 @@ fn runs_biodivine() -> Result<(), Box<dyn std::error::Error>> {
     let wrong_file = assert_fs::NamedTempFile::new("wrong_format.adf")?;
     wrong_file.write_str("s(7).s(4).s(8).s(3).s(5).s(9).s(10).s(1).s(6).s(2).ac(7,or(or(and(7,neg(1)),neg(9)),3)).ac(4,5).ac(8,or(or(8,1),neg(7))).ac(3,or(and(or(6,7),neg(and(6,7))),neg(2))).ac(5,c(f)).ac(9,and(neg(7),2)).ac(10,or(neg(2),6)).ac(1,and(or(or(neg(2),neg(1)),8),7)).ac(6,and(and(neg(2),10),and(or(7,4),neg(and(7,4))))).ac(2,and(and(and(neg(10),3),neg(6)),or(9,1)))).")?;
 
-    let mut cmd = Command::cargo_bin("adf_bdd")?;
+    let mut cmd = Command::cargo_bin("adf-bdd")?;
 
     cmd.arg(wrong_file.path());
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("code: Eof"));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path()).arg("-vv").arg("--grd");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path()).arg("-q").arg("--grd");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path()).arg("--lx").arg("-v").arg("--grd");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(10) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path()).arg("--an").arg("--grd").arg("--stm");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.env_clear();
     cmd.arg(file.path()).arg("--an").arg("--grd");
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -228,7 +228,7 @@ fn runs_biodivine() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -237,7 +237,7 @@ fn runs_biodivine() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--com")
@@ -256,14 +256,14 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
     let wrong_file = assert_fs::NamedTempFile::new("wrong_format.adf")?;
     wrong_file.write_str("s(7).s(4).s(8).s(3).s(5).s(9).s(10).s(1).s(6).s(2).ac(7,or(or(and(7,neg(1)),neg(9)),3)).ac(4,5).ac(8,or(or(8,1),neg(7))).ac(3,or(and(or(6,7),neg(and(6,7))),neg(2))).ac(5,c(f)).ac(9,and(neg(7),2)).ac(10,or(neg(2),6)).ac(1,and(or(or(neg(2),neg(1)),8),7)).ac(6,and(and(neg(2),10),and(or(7,4),neg(and(7,4))))).ac(2,and(and(and(neg(10),3),neg(6)),or(9,1)))).")?;
 
-    let mut cmd = Command::cargo_bin("adf_bdd")?;
+    let mut cmd = Command::cargo_bin("adf-bdd")?;
 
     cmd.arg(wrong_file.path());
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("code: Eof"));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("-vv")
         .arg("--grd")
@@ -273,7 +273,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("-q")
         .arg("--grd")
@@ -283,7 +283,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(7) F(4) u(8) u(3) F(5) u(9) u(10) u(1) u(6) u(2)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--lx")
         .arg("-v")
@@ -294,7 +294,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(10) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9)",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -305,7 +305,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.env_clear();
     cmd.arg(file.path())
         .arg("--an")
@@ -316,7 +316,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -328,7 +328,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
 
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--grd")
@@ -339,7 +339,7 @@ fn runs_biodivine_hybrid() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success().stdout(predicate::str::contains(
         "u(1) u(2) u(3) F(4) F(5) u(6) u(7) u(8) u(9) u(10) \n",
     ));
-    cmd = Command::cargo_bin("adf_bdd")?;
+    cmd = Command::cargo_bin("adf-bdd")?;
     cmd.arg(file.path())
         .arg("--an")
         .arg("--com")


### PR DESCRIPTION
# What does this PR do?

* Changed the binary name to be written in kebab-case as a distinction to the snake-case library name
* Use the crates.io crate for the binary now


