### PR TITLE
Fix link location in all readme files for KBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ the Bundesministerium für Bildung und Forschung (BMBF, Federal Ministry of Educ
 and by the [Center for Advancing Electronics Dresden](https://cfaed.tu-dresden.de) (cfaed).
 
 # Affiliation 
-This work has been party developed by the [Knowledge-Based Systems Group](https://iccl.inf.tu-dresden.de/web/Wissensbasierte_Systeme/en), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
+This work has been party developed by the [Knowledge-Based Systems Group](http://kbs.inf.tu-dresden.de/), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
 
 # Disclaimer
 Hosting content here does not establish any formal or legal relation to TU Dresden

--- a/bin/README.md
+++ b/bin/README.md
@@ -121,7 +121,7 @@ the Bundesministerium für Bildung und Forschung (BMBF, Federal Ministry of Educ
 and by the [Center for Advancing Electronics Dresden](https://cfaed.tu-dresden.de) (cfaed).
 
 # Affiliation 
-This work has been party developed by the [Knowledge-Based Systems Group](https://iccl.inf.tu-dresden.de/web/Wissensbasierte_Systeme/en), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
+This work has been party developed by the [Knowledge-Based Systems Group](http://kbs.inf.tu-dresden.de/), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
 
 # Disclaimer
 Hosting content here does not establish any formal or legal relation to TU Dresden

--- a/lib/README.md
+++ b/lib/README.md
@@ -121,7 +121,7 @@ the Bundesministerium für Bildung und Forschung (BMBF, Federal Ministry of Educ
 and by the [Center for Advancing Electronics Dresden](https://cfaed.tu-dresden.de) (cfaed).
 
 # Affiliation 
-This work has been party developed by the [Knowledge-Based Systems Group](https://iccl.inf.tu-dresden.de/web/Wissensbasierte_Systeme/en), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
+This work has been party developed by the [Knowledge-Based Systems Group](http://kbs.inf.tu-dresden.de/), [Faculty of Computer Science](https://tu-dresden.de/ing/informatik)  of [TU Dresden](https://tu-dresden.de).
 
 # Disclaimer
 Hosting content here does not establish any formal or legal relation to TU Dresden


### PR DESCRIPTION
# What does this PR do?

Update link to the short-link for the kbs