### PR TITLE
Update Documentation navigation

### DIFF
--- a/docs/adf-bdd.md
+++ b/docs/adf-bdd.md
@@ -8,6 +8,9 @@
 ![Crates.io](https://img.shields.io/crates/l/adf_bdd)
 [![GitHub Discussions](https://img.shields.io/github/discussions/ellmau/adf-obdd)](https://github.com/ellmau/adf-obdd/discussions) ![rust-edition](https://img.shields.io/badge/Rust--edition-2021-blue?logo=rust)
 
+| [Home](index.md) | [Binary](adf-bdd.md) | [Library](adf_bdd.md)| [Repository](https://github.com/ellmau/adf-obdd) |
+|--- | --- | --- | --- |
+
 # Abstract Dialectical Frameworks solved by Binary Decision Diagrams; developed in Dresden (ADF-BDD) 
 This is the readme for the executable solver.
 

--- a/docs/adf_bdd.md
+++ b/docs/adf_bdd.md
@@ -8,6 +8,9 @@
 ![Crates.io](https://img.shields.io/crates/l/adf_bdd)
 [![GitHub Discussions](https://img.shields.io/github/discussions/ellmau/adf-obdd)](https://github.com/ellmau/adf-obdd/discussions) ![rust-edition](https://img.shields.io/badge/Rust--edition-2021-blue?logo=rust)
 
+| [Home](index.md) | [Binary](adf-bdd.md) | [Library](adf_bdd.md)| [Repository](https://github.com/ellmau/adf-obdd) |
+|--- | --- | --- | --- |
+
 # Abstract Dialectical Frameworks solved by Binary Decision Diagrams; developed in Dresden (ADF_BDD) 
 This library contains an efficient representation of Abstract Dialectical Frameworks (ADf) by utilising an implementation of Ordered Binary Decision Diagrams (OBDD)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,9 @@
 ![Crates.io](https://img.shields.io/crates/l/adf_bdd)
 [![GitHub Discussions](https://img.shields.io/github/discussions/ellmau/adf-obdd)](https://github.com/ellmau/adf-obdd/discussions) ![rust-edition](https://img.shields.io/badge/Rust--edition-2021-blue?logo=rust)
 
+| [Home](index.md) | [Binary](adf-bdd.md) | [Library](adf_bdd.md)| [Repository](https://github.com/ellmau/adf-obdd) |
+|--- | --- | --- | --- |
+
 # Abstract Dialectical Frameworks solved by (ordered) Binary Decision Diagrams; developed in Dresden (ADF-oBDD project)
 
 This project is currently split into two parts:


### PR DESCRIPTION
Adding some navigation to the top of the documentation file. 

TODO: get some automated navigation done

# What does this PR do?

* Describe what the PR does
* Adding some navigation links to the top of the landing-page sites

# Checklist before creating a non-draft PR

- [-] All tests are passing
- [-] Clippy has no complains
- [-] Code is `rustfmt` formatted
- [-] Applicable labels are chosen (Note: it is not necessary to replicate the labels from the related issues)
- [-] There are no other open [Pull Requests](https://github.com/ellmau/adf-obdd/pulls) for the same update/change.
  - [-] If there is a good reason to have another PR for the same update/change, it is well justified.

# Checklist on Guidelines and Conventions

- [-] Commit messages follow our guidelines
- [-] Code is self-reviewed
- [-] Naming conventions are met
- [-] New features are tested
  - [ ] `quickcheck` has been considered
  - [ ] All variants are considered and checked
- Clippy Compiler-exceptions
  - [-] Used in a sparse manner
  - [-] If used, a separate comment describes and justifies its use
- [-] `rustdoc` comments are self-reviewed and descriptive
- Error handling
  - [-] Use of `panic!(...)` applications is justified on non-recoverable situations
  - [-] `expect(...)` is used over `unwrap()` (except obvious test-cases)
- [-] No unsafe code (exceptions need to be discussed specifically)
