### PR TITLE
Add a random heuristic, based on rand-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "nom",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.8.5",
  "roaring",
  "serde",
  "serde_json",
@@ -622,7 +623,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
 ]
@@ -633,6 +634,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
 ]
 
@@ -644,6 +647,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,6 +33,7 @@ derivative = "2.2.0"
 roaring = "0.9.0"
 strum = { version = "0.24", features = ["derive"] }
 crossbeam-channel = "0.5"
+rand = {version = "0.8.5", features = ["std_rng"]}
 
 [dev-dependencies]
 test-log = "0.2"

--- a/lib/src/adf.rs
+++ b/lib/src/adf.rs
@@ -146,9 +146,15 @@ impl Adf {
         RefCell::new(StdRng::from_entropy())
     }
 
-    /// sets a seed based on a [u64] value
+    /// Sets a seed based on a [u64] value
+    /// Do *not* use in serious conditions - use [`crypto_seed`][Adf::crypto_seed] instead
     pub fn seed(&mut self, seed: u64) {
         self.rng = RefCell::new(StdRng::seed_from_u64(seed));
+    }
+
+    /// Sets a cryptographiclly strong seed
+    pub fn crypto_seed(&mut self, seed: [u8; 32]) {
+        self.rng = RefCell::new(StdRng::from_seed(seed))
     }
 
     /// Instantiates a new ADF, based on a [biodivine adf][crate::adfbiodivine::Adf].
@@ -1263,6 +1269,14 @@ mod test {
         adf.seed(55120);
         let result = adf.stable_nogood(Heuristic::Rand).collect::<Vec<_>>();
         assert_eq!(result, vec![vec![Term(0), Term(1)], vec![Term(1), Term(0)]]);
+
+        let mut adf = Adf::from_parser(&parser);
+        adf.crypto_seed([
+            122, 186, 240, 42, 235, 102, 89, 81, 187, 203, 127, 188, 167, 198, 126, 156, 25, 205,
+            204, 132, 112, 93, 23, 193, 21, 108, 166, 231, 158, 250, 128, 135,
+        ]);
+        let result = adf.stable_nogood(Heuristic::Rand).collect::<Vec<_>>();
+        assert_eq!(result, vec![vec![Term(1), Term(0)], vec![Term(0), Term(1)]]);
     }
 
     #[test]

--- a/lib/src/adf.rs
+++ b/lib/src/adf.rs
@@ -146,14 +146,8 @@ impl Adf {
         RefCell::new(StdRng::from_entropy())
     }
 
-    /// Sets a seed based on a [u64] value
-    /// Do *not* use in serious conditions - use [`crypto_seed`][Adf::crypto_seed] instead
-    pub fn seed(&mut self, seed: u64) {
-        self.rng = RefCell::new(StdRng::seed_from_u64(seed));
-    }
-
     /// Sets a cryptographiclly strong seed
-    pub fn crypto_seed(&mut self, seed: [u8; 32]) {
+    pub fn seed(&mut self, seed: [u8; 32]) {
         self.rng = RefCell::new(StdRng::from_seed(seed))
     }
 
@@ -1266,12 +1260,7 @@ mod test {
         assert_eq!(result.len(), 2);
 
         let mut adf = Adf::from_parser(&parser);
-        adf.seed(55120);
-        let result = adf.stable_nogood(Heuristic::Rand).collect::<Vec<_>>();
-        assert_eq!(result, vec![vec![Term(0), Term(1)], vec![Term(1), Term(0)]]);
-
-        let mut adf = Adf::from_parser(&parser);
-        adf.crypto_seed([
+        adf.seed([
             122, 186, 240, 42, 235, 102, 89, 81, 187, 203, 127, 188, 167, 198, 126, 156, 25, 205,
             204, 132, 112, 93, 23, 193, 21, 108, 166, 231, 158, 250, 128, 135,
         ]);

--- a/lib/src/adf.rs
+++ b/lib/src/adf.rs
@@ -6,6 +6,8 @@ This module describes the abstract dialectical framework.
 */
 
 pub mod heuristics;
+use std::cell::RefCell;
+
 use crate::{
     datatypes::{
         adf::{
@@ -18,6 +20,7 @@ use crate::{
     obdd::Bdd,
     parser::{AdfParser, Formula},
 };
+use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 use self::heuristics::Heuristic;
@@ -30,6 +33,8 @@ pub struct Adf {
     ordering: VarContainer,
     bdd: Bdd,
     ac: Vec<Term>,
+    #[serde(skip, default = "Adf::default_rng")]
+    rng: RefCell<StdRng>,
 }
 
 impl Default for Adf {
@@ -38,6 +43,7 @@ impl Default for Adf {
             ordering: VarContainer::default(),
             bdd: Bdd::new(),
             ac: Vec::new(),
+            rng: Adf::default_rng(),
         }
     }
 }
@@ -50,6 +56,7 @@ impl Adf {
             ordering: parser.var_container(),
             bdd: Bdd::new(),
             ac: vec![Term(0); parser.dict_size()],
+            rng: Adf::default_rng(),
         };
         (0..parser.dict_size()).into_iter().for_each(|value| {
             log::trace!("adding variable {}", Var(value));
@@ -85,6 +92,7 @@ impl Adf {
             ordering: ordering.clone(),
             bdd: Bdd::new(),
             ac: vec![Term(0); bio_ac.len()],
+            rng: Adf::default_rng(),
         };
         result
             .ac
@@ -132,6 +140,15 @@ impl Adf {
         log::trace!("ordering: {:?}", result.ordering);
         log::trace!("adf {:?} instantiated with bdd {}", result.ac, result.bdd);
         result
+    }
+
+    fn default_rng() -> RefCell<StdRng> {
+        RefCell::new(StdRng::from_entropy())
+    }
+
+    /// sets a seed based on a [u64] value
+    pub fn seed(&mut self, seed: u64) {
+        self.rng = RefCell::new(StdRng::seed_from_u64(seed));
     }
 
     /// Instantiates a new ADF, based on a [biodivine adf][crate::adfbiodivine::Adf].
@@ -1230,6 +1247,22 @@ mod test {
             ]
         );
         solving.join().unwrap();
+    }
+
+    #[test]
+    fn rand_stable_heu() {
+        let parser = AdfParser::default();
+        parser.parse()("s(a).s(b).ac(a,neg(b)).ac(b,neg(a)).").unwrap();
+        let mut adf = Adf::from_parser(&parser);
+        let result = adf.stable_nogood(Heuristic::Rand).collect::<Vec<_>>();
+        assert!(result.contains(&vec![Term(0), Term(1)]));
+        assert!(result.contains(&vec![Term(1), Term(0)]));
+        assert_eq!(result.len(), 2);
+
+        let mut adf = Adf::from_parser(&parser);
+        adf.seed(55120);
+        let result = adf.stable_nogood(Heuristic::Rand).collect::<Vec<_>>();
+        assert_eq!(result, vec![vec![Term(0), Term(1)], vec![Term(1), Term(0)]]);
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

* Add a random engine to each ADF
* Choose to use a random value or a u64 seed
* Allow to use a random-heuristics

# Checklist before creating a non-draft PR

- [x] All tests are passing
- [x] Clippy has no complains
- [x] Code is `rustfmt` formatted
- [x] Applicable labels are chosen (Note: it is not necessary to replicate the labels from the related issues)
- [x] There are no other open [Pull Requests](https://github.com/ellmau/adf-obdd/pulls) for the same update/change.
  - [ ] If there is a good reason to have another PR for the same update/change, it is well justified.

# Checklist on Guidelines and Conventions

- [x] Commit messages follow our guidelines
- [x] Code is self-reviewed
- [x] Naming conventions are met
- [x] New features are tested
  - [x] `quickcheck` has been considered
  - [x] All variants are considered and checked
- Clippy Compiler-exceptions
  - [x] Used in a sparse manner
  - [x] If used, a separate comment describes and justifies its use
- [x] `rustdoc` comments are self-reviewed and descriptive
- Error handling
  - [x] Use of `panic!(...)` applications is justified on non-recoverable situations
  - [x] `expect(...)` is used over `unwrap()` (except obvious test-cases)
- [x] No unsafe code (exceptions need to be discussed specifically)
