### PR TITLE
Fix typo in info text

### DIFF
--- a/frontend/src/help-texts/add-info.md
+++ b/frontend/src/help-texts/add-info.md
@@ -3,7 +3,7 @@ The Web UI mimics many options of the CLI version of the [underlying adf-bdd too
 
 In the below form, you can either type/paste your `code` or upload a file in the same format.
 To put it briefly, an ADF consists of statements and accectance conditions for these statements.
-For instance, the following code indicates that `a,b,c,d` are statements, that `a` is assumed to be true (verum), `b` is true if is true (which is tautological), `c` is true if `a` and `b` are true, and `d` is true if `b` is false.
+For instance, the following code indicates that `a,b,c,d` are statements, that `a` is assumed to be true (verum), `b` is true if `b` is true (which is self-supporting), `c` is true if `a` and `b` are true, and `d` is true if `b` is false.
 
 ```
 s(a).


### PR DESCRIPTION
# What does this PR do?

* Fixes a typo in the info text in the webapp.

# Checklist before creating a non-draft PR

- [x] All tests are passing
- [x] Clippy has no complains
- [x] Code is `rustfmt` formatted
- [x] Applicable labels are chosen (Note: it is not necessary to replicate the labels from the related issues)
- [x] There are no other open [Pull Requests](https://github.com/ellmau/adf-obdd/pulls) for the same update/change.
  - [x] If there is a good reason to have another PR for the same update/change, it is well justified.

# Checklist on Guidelines and Conventions

- [x] Commit messages follow our guidelines
- [x] Code is self-reviewed
- [x] Naming conventions are met
- [x] New features are tested
  - [x] `quickcheck` has been considered
  - [x] All variants are considered and checked
- Clippy Compiler-exceptions
  - [x] Used in a sparse manner
  - [x] If used, a separate comment describes and justifies its use
- [x] `rustdoc` comments are self-reviewed and descriptive
- Error handling
  - [x] Use of `panic!(...)` applications is justified on non-recoverable situations
  - [x] `expect(...)` is used over `unwrap()` (except obvious test-cases)
- [x] No unsafe code (exceptions need to be discussed specifically)
